### PR TITLE
feat: bump tensorflow from 2.8.0 to 2.8.2 to fix vulnerabilities

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -19,10 +19,10 @@
 | [tensorboard-data-server](https://github.com/tensorflow/tensorboard/tree/master/tensorboard/data/server) | 0.6.1 | python3_ia |
 | [tensorboard-plugin-wit](https://whatif-tool.dev) | 1.8.0 | python3_ia |
 | [tensorboard](https://github.com/tensorflow/tensorboard) | 2.8.0 | python3_ia |
+| [tensorflow-estimator](https://www.tensorflow.org/) | 2.8.0 | python3_ia |
 | [tensorflow-io-gcs-filesystem](https://github.com/tensorflow/io) | 0.23.1 | python3_ia |
-| [tensorflow](https://www.tensorflow.org/) | 2.8.0 | python3_ia |
+| [tensorflow](https://www.tensorflow.org/) | 2.8.2 | python3_ia |
 | [termcolor](http://pypi.python.org/pypi/termcolor) | 1.1.0 | python3_ia |
-| [tf-estimator-nightly](https://www.tensorflow.org/) | 2.8.0.dev2021122109 | python3_ia |
 | [torch](https://pytorch.org/) | 1.8.1 | python3_ia |
 
 *(24 components)*

--- a/layers/layer5_python3_ia/0500_extra_packages/requirements3.txt
+++ b/layers/layer5_python3_ia/0500_extra_packages/requirements3.txt
@@ -17,8 +17,8 @@ rsa==4.7.2
 tensorboard==2.8.0
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.0
-tensorflow==2.8.0
+tensorflow==2.8.2
+tensorflow-estimator==2.8.0
 tensorflow-io-gcs-filesystem==0.23.1
 termcolor==1.1.0
-tf-estimator-nightly==2.8.0.dev2021122109
 torch==1.8.1


### PR DESCRIPTION
Close: #85