### PR TITLE
feat: bump transformers from 4.48.3 to 4.51.3 (fix CVE-2025-1194)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -11,7 +11,7 @@
 | [google-auth](https://github.com/googleapis/google-auth-library-python) | 2.25.2 | python3_ia |
 | [google-pasta](https://github.com/google/pasta) | 0.2.0 | python3_ia |
 | [grpcio](https://grpc.io) | 1.60.0 | python3_ia |
-| [huggingface_hub](https://github.com/huggingface/huggingface_hub) | 0.24.7 | python3_ia |
+| [huggingface_hub](https://github.com/huggingface/huggingface_hub) | 0.30.2 | python3_ia |
 | [keras](https://pypi.org/project/keras) | 3.9.0 | python3_ia |
 | [libclang](https://github.com/sighingnow/libclang) | 16.0.6 | python3_ia |
 | [lightning-utilities](https://github.com/Lightning-AI/utilities) | 0.14.2 | python3_ia |
@@ -45,7 +45,7 @@
 | [pytorch-lightning](https://github.com/Lightning-AI/lightning) | 2.5.1 | python3_ia |
 | [requests-oauthlib](https://github.com/requests/requests-oauthlib) | 1.3.1 | python3_ia |
 | [rsa](https://stuvel.eu/rsa) | 4.9 | python3_ia |
-| [safetensors](https://github.com/huggingface/safetensors) | 0.4.1 | python3_ia |
+| [safetensors](https://github.com/huggingface/safetensors) | 0.5.3 | python3_ia |
 | [segmentation_models_pytorch](https://github.com/qubvel/segmentation_models.pytorch) | 0.3.3 | python3_ia |
 | [sympy](https://sympy.org) | 1.13.3 | python3_ia |
 | [tensorboard-data-server](https://github.com/tensorflow/tensorboard/tree/master/tensorboard/data/server) | 0.7.2 | python3_ia |
@@ -58,7 +58,7 @@
 | [torch](https://pytorch.org/) | 2.7.0 | python3_ia |
 | [torchmetrics](https://github.com/Lightning-AI/torchmetrics) | 1.3.0.post0 | python3_ia |
 | [torchvision](https://github.com/pytorch/vision) | 0.22.0 | python3_ia |
-| [transformers](https://github.com/huggingface/transformers) | 4.48.3 | python3_ia |
+| [transformers](https://github.com/huggingface/transformers) | 4.51.3 | python3_ia |
 | [triton](https://github.com/triton-lang/triton/) | 3.3.0 | python3_ia |
 
 *(60 components)*

--- a/layers/layer5_python3_ia/0500_extra_packages/requirements3.txt
+++ b/layers/layer5_python3_ia/0500_extra_packages/requirements3.txt
@@ -9,7 +9,7 @@ google-auth==2.25.2
 google-auth-oauthlib==1.2.0
 google-pasta==0.2.0
 grpcio==1.60.0
-huggingface_hub==0.24.7
+huggingface_hub==0.30.2
 keras==3.9.0
 libclang==16.0.6
 lightning==2.5.1
@@ -43,7 +43,7 @@ pretrainedmodels==0.7.4
 pytorch-lightning==2.5.1
 requests-oauthlib==1.3.1
 rsa==4.9
-safetensors==0.4.1
+safetensors==0.5.3
 segmentation_models_pytorch==0.3.3
 sympy==1.13.3
 tensorboard==2.19.0
@@ -56,5 +56,5 @@ tokenizers==0.21.0
 torch==2.7.0
 torchmetrics==1.3.0.post0
 torchvision==0.22.0
-transformers==4.48.3
+transformers==4.51.3
 triton==3.3.0


### PR DESCRIPTION
also bump dependencies :
- safetensors from 0.4.1 to 0.5.3
- huggingface_hub from 0.24.7 to 0.30.2