### PR TITLE
feat: bump onnx from 1.20.1 to 1.21.0 (fix CVE-2026-34445/28500)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -48,7 +48,7 @@
 | [nvidia-nvtx-cu12](https://developer.nvidia.com/cuda-zone) | 12.8.90 | python3_ia |
 | [oauthlib](https://github.com/oauthlib/oauthlib) | 3.2.2 | python3_ia |
 | [omegaconf](https://github.com/omry/omegaconf) | 2.3.0 | python3_ia |
-| [onnx](https://onnx.ai/) | 1.20.1 | python3_ia |
+| [onnx](https://onnx.ai/) | 1.21.0 | python3_ia |
 | [onnxruntime](https://onnxruntime.ai) | 1.24.4 | python3_ia |
 | [onnxscript](https://microsoft.github.io/onnxscript/) | 0.2.5 | python3_ia |
 | [opt_einsum](https://pypi.org/project/opt_einsum) | 3.4.0 | python3_ia |

--- a/layers/layer5_python3_ia/0500_extra_packages/requirements3.txt
+++ b/layers/layer5_python3_ia/0500_extra_packages/requirements3.txt
@@ -46,7 +46,7 @@ nvidia-nvshmem-cu12==3.4.5
 nvidia-nvtx-cu12==12.8.90
 oauthlib==3.2.2
 omegaconf==2.3.0
-onnx==1.20.1
+onnx==1.21.0
 onnxruntime==1.24.4
 onnxscript==0.2.5
 opt-einsum==3.4.0


### PR DESCRIPTION
fix other moderate and high CVEs