### PR TITLE
feat: bump transformers from 4.53.3 to 5.3.0 (fix moderate CVE-2026-1…

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -1,6 +1,7 @@
 | Name | Version | Layer |
 | --- | --- | --- |
 | [absl-py](https://github.com/abseil/abseil-py) | 2.2.2 | python3_ia |
+| [annotated-doc](https://github.com/fastapi/annotated-doc) | 0.0.4 | python3_ia |
 | [antlr4-python3-runtime](http://www.antlr.org) | 4.9.3 | python3_ia |
 | [astunparse](https://github.com/simonpercivall/astunparse) | 1.6.3 | python3_ia |
 | [axial_attention](https://github.com/lucidrains/axial-attention) | 0.6.1 | python3_ia |
@@ -16,7 +17,8 @@
 | [google-auth](https://github.com/googleapis/google-auth-library-python) | 2.41.1 | python3_ia |
 | [google-pasta](https://github.com/google/pasta) | 0.2.0 | python3_ia |
 | [grpcio](https://grpc.io) | 1.76.0 | python3_ia |
-| [huggingface_hub](https://github.com/huggingface/huggingface_hub) | 0.31.4 | python3_ia |
+| [hf-xet](https://github.com/huggingface/xet-core) | 1.4.3 | python3_ia |
+| [huggingface_hub](https://github.com/huggingface/huggingface_hub) | 1.5.0 | python3_ia |
 | [hydra-core](https://github.com/facebookresearch/hydra) | 1.3.2 | python3_ia |
 | [jsonargparse](https://pypi.org/project/jsonargparse) | 4.46.0 | python3_ia |
 | [jsonnet](https://jsonnet.org) | 0.21.0 | python3_ia |
@@ -63,18 +65,19 @@
 | [tabulate](https://github.com/astanin/python-tabulate) | 0.9.0 | python3_ia |
 | [tensorboard-data-server](https://github.com/tensorflow/tensorboard/tree/master/tensorboard/data/server) | 0.7.2 | python3_ia |
 | [tensorboard](https://github.com/tensorflow/tensorboard) | 2.20.0 | python3_ia |
+| [tensorboardX](https://github.com/lanpa/tensorboardX) | 2.6.5 | python3_ia |
 | [tensorflow-hub](https://github.com/tensorflow/hub) | 0.16.1 | python3_ia |
 | [tensorflow](https://www.tensorflow.org/) | 2.20.0 | python3_ia |
 | [tf_keras](https://keras.io/) | 2.20.1 | python3_ia |
 | [tiktoken](https://github.com/openai/tiktoken) | 0.12.0 | python3_ia |
 | [timm](https://github.com/huggingface/pytorch-image-models) | 1.0.22 | python3_ia |
-| [tokenizers](https://github.com/huggingface/tokenizers) | 0.21.1 | python3_ia |
+| [tokenizers](https://github.com/huggingface/tokenizers) | 0.22.2 | python3_ia |
 | [torch-geometric](https://pyg.org) | 2.7.0 | python3_ia |
 | [torch](https://pytorch.org) | 2.10.0 | python3_ia |
 | [torchmetrics](https://github.com/Lightning-AI/torchmetrics) | 1.9.0 | python3_ia |
 | [torchvision](https://github.com/pytorch/vision) | 0.25.0 | python3_ia |
-| [transformers](https://github.com/huggingface/transformers) | 4.53.3 | python3_ia |
+| [transformers](https://github.com/huggingface/transformers) | 5.3.0 | python3_ia |
 | [triton](https://github.com/triton-lang/triton/) | 3.6.0 | python3_ia |
 | [typeshed_client](https://github.com/JelleZijlstra/typeshed_client) | 2.8.2 | python3_ia |
 
-*(76 components)*
+*(79 components)*

--- a/integration_tests/0003_test_import_python3_ia/import_python3_ia.py
+++ b/integration_tests/0003_test_import_python3_ia/import_python3_ia.py
@@ -1,4 +1,5 @@
 import absl #absl_py
+import annotated_doc
 import antlr4 #antlr4-python3-runtime
 import astunparse
 import axial_attention
@@ -12,6 +13,7 @@ import google_auth_oauthlib
 import google #google_auth
 import pasta #google_pasta
 import grpc #grpcio
+import hf_xet
 import huggingface_hub
 import hydra #hydra-core
 import jsonargparse
@@ -57,6 +59,7 @@ import sympy
 import tabulate
 import tensorboard_data_server
 import tensorboard
+import tensorboardX
 import tensorflow
 import tensorflow_hub
 import tf_keras

--- a/layers/layer5_python3_ia/0500_extra_packages/allow_binary_packages
+++ b/layers/layer5_python3_ia/0500_extra_packages/allow_binary_packages
@@ -11,6 +11,7 @@ google-auth
 google-auth-oauthlib
 google-pasta
 grpcio
+hf_xet
 hydra-core
 Keras
 keras-nightly

--- a/layers/layer5_python3_ia/0500_extra_packages/requirements3.txt
+++ b/layers/layer5_python3_ia/0500_extra_packages/requirements3.txt
@@ -1,4 +1,5 @@
 absl-py==2.2.2
+annotated-doc==0.0.4
 antlr4_python3_runtime==4.9.3
 astunparse==1.6.3
 axial_attention==0.6.1
@@ -14,7 +15,8 @@ google-auth==2.41.1
 google-auth-oauthlib==1.2.2
 google-pasta==0.2.0
 grpcio==1.76.0
-huggingface_hub==0.31.4
+hf_xet==1.4.3
+huggingface_hub==1.5.0
 hydra-core==1.3.2
 jsonargparse==4.46.0
 jsonnet==0.21.0
@@ -61,16 +63,17 @@ sympy==1.14.0
 tabulate==0.9.0
 tensorboard==2.20.0
 tensorboard-data-server==0.7.2
+tensorboardx==2.6.5
 tensorflow==2.20.0
 tensorflow-hub==0.16.1
 tf-keras==2.20.1
 tiktoken==0.12.0
 timm==1.0.22
-tokenizers==0.21.1
+tokenizers==0.22.2
 torch==2.10.0
 torchmetrics==1.9.0
 torchvision==0.25.0
 torch-geometric==2.7.0
-transformers==4.53.3
+transformers==5.3.0
 triton==3.6.0
 typeshed-client==2.8.2


### PR DESCRIPTION
also upgrade :
- huggingface_hub from 0.31.4 to 1.5.0
- tokenizers from 0.21.1 to 0.22.2

and add :
- annotated-doc 0.0.4
- hf-xet 1.4.3
- tensorboardX 2.6.5 (previously missing, nothing to do with transformers)